### PR TITLE
MCO as runtime configurable option

### DIFF
--- a/src/main/drivers/mco.c
+++ b/src/main/drivers/mco.c
@@ -33,8 +33,9 @@ void mcoInit(const mcoConfig_t *mcoConfig)
 {
     // Only configure MCO2 with PLLI2SCLK as source for now.
     // Other MCO1 and other sources can easily be added.
+    // For all F4 and F7 varianets, MCO1 is on PA8 and MCO2 is on PC9.
 
-    if (mcoConfig->ioTag[1]) {
+    if (mcoConfig->ioTag[1] == IO_TAG(PC9)) {
         IO_t io = IOGetByTag(mcoConfig->ioTag[1]);
 #ifdef STM32F7
         HAL_RCC_MCOConfig(RCC_MCO2, RCC_MCO2SOURCE_PLLI2SCLK, RCC_MCODIV_4);


### PR DESCRIPTION
- Define `USE_MCO` (It is already defined as MCU specific build option for STM32F4 and STM32F7.)
- Define `MCO2_PIN` in `target.h` (E.g., `#define MCO2_PIN PC9`).
- Above target specific pin definition will be gone in 4.0. You will have to add CLI `resource MCO 2 C9` to post-flash configuration.

Please rebase `pll_osd_clock` to current master to merge this PR.