### PR TITLE
Small changes for mco

### DIFF
--- a/src/main/drivers/mco.c
+++ b/src/main/drivers/mco.c
@@ -40,6 +40,9 @@ void mcoInit(const mcoConfig_t *mcoConfig)
 #ifdef STM32F7
         HAL_RCC_MCOConfig(RCC_MCO2, RCC_MCO2SOURCE_PLLI2SCLK, RCC_MCODIV_4);
         IOConfigGPIOAF(io, IO_CONFIG(GPIO_MODE_AF_PP, GPIO_SPEED_FREQ_VERY_HIGH,  GPIO_NOPULL), GPIO_AF0_MCO);
+#else
+        // Not implemented for F4 (yet).
+        UNUSED(io);
 #endif
     }
 }

--- a/src/main/target/OMNIBUSF7/target.h
+++ b/src/main/target/OMNIBUSF7/target.h
@@ -20,9 +20,6 @@
 
 #pragma once
 
-#define USE_MCO
-#define MCO2_PIN PC9
-
 //OMNIBUSF7 TARGETS-------------------------
 #define USE_TARGET_CONFIG
 #if defined (FPVM_BETAFLIGHTF7)


### PR DESCRIPTION
This PR will
- Protect F4 targets from emitting unused variable warnings.
- Reinstate `target.h` for `OMNIBUSF7` which has been used as a test target.

Now, after merging this PR, you should squash commits into one.

1. `git rebase -i HEAD~4`

2. When an editor comes up with a list commits
```
pick 66cf856 MCO2 output as run time configurable option
pick e8cebfa Add sanity check for MCO2 pin
pick 00a89f1 changed output mode to AF from OUTPUT in mco driver
pick 54a3d8c MCO for F4 is not implemented yet
```
change `pick` to `s` (for squash) on lines 2, 3 and 4
```
pick 66cf856 MCO2 output as run time configurable option
s e8cebfa Add sanity check for MCO2 pin
s 00a89f1 changed output mode to AF from OUTPUT in mco driver
s 54a3d8c MCO for F4 is not implemented yet
```
then save and quit the editor.
3. git will squash 4 commit into one. On the due course, git will ask you to edit commit message. You can change your commit message to something that explains the entire commit; e.g., "Add MCO facility".
4. Push the resulting branch; `git push --force-with-lease`.