### PR TITLE
Add config variable mco2_on_pc9

### DIFF
--- a/src/main/drivers/mco.c
+++ b/src/main/drivers/mco.c
@@ -35,10 +35,11 @@ void mcoInit(const mcoConfig_t *mcoConfig)
     // Other MCO1 and other sources can easily be added.
     // For all F4 and F7 varianets, MCO1 is on PA8 and MCO2 is on PC9.
 
-    if (mcoConfig->ioTag[1] == IO_TAG(PC9)) {
+    if (mcoConfig->ioTag[1] == IO_TAG(PC9) && mcoConfig->enabled[1]) {
         IO_t io = IOGetByTag(mcoConfig->ioTag[1]);
 #ifdef STM32F7
         HAL_RCC_MCOConfig(RCC_MCO2, RCC_MCO2SOURCE_PLLI2SCLK, RCC_MCODIV_4);
+        IOInit(io, OWNER_MCO, 2);
         IOConfigGPIOAF(io, IO_CONFIG(GPIO_MODE_AF_PP, GPIO_SPEED_FREQ_VERY_HIGH,  GPIO_NOPULL), GPIO_AF0_MCO);
 #else
         // Not implemented for F4 (yet).

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -72,6 +72,7 @@
 #include "pg/flash.h"
 #include "pg/gyrodev.h"
 #include "pg/max7456.h"
+#include "pg/mco.h"
 #include "pg/pg.h"
 #include "pg/pg_ids.h"
 #include "pg/pinio.h"
@@ -1189,6 +1190,9 @@ const clivalue_t valueTable[] = {
     { "gyro_2_i2cBus",  VAR_UINT8 | MASTER_VALUE, .config.minmax = { 0, I2CDEV_COUNT }, PG_GYRO_DEVICE_CONFIG, PG_ARRAY_ELEMENT_OFFSET(gyroDeviceConfig_t, 1, i2cBus) },
     { "gyro_2_i2c_address", VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, I2C_ADDR7_MAX }, PG_GYRO_DEVICE_CONFIG, PG_ARRAY_ELEMENT_OFFSET(gyroDeviceConfig_t, 1, i2cAddress) },
     { "gyro_2_sensor_align", VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_ALIGNMENT }, PG_GYRO_DEVICE_CONFIG, PG_ARRAY_ELEMENT_OFFSET(gyroDeviceConfig_t, 1, align) },
+#endif
+#ifdef USE_MCO
+    { "mco2_on_pc9",    VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_MCO_CONFIG, PG_ARRAY_ELEMENT_OFFSET(mcoConfig_t, 1, enabled) },
 #endif
 };
 

--- a/src/main/pg/mco.h
+++ b/src/main/pg/mco.h
@@ -28,6 +28,7 @@
 
 typedef struct mcoConfig_s {
     ioTag_t ioTag[2];
+    uint8_t enabled[2];
 } mcoConfig_t;
 
 PG_DECLARE(mcoConfig_t, mcoConfig);

--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -51,6 +51,7 @@
 #define USE_SRAM2
 #if defined(STM32F40_41xxx)
 #define USE_FAST_RAM
+#define USE_MCO
 #endif
 #define USE_DSHOT
 #define I2C3_OVERCLOCK true
@@ -59,7 +60,6 @@
 #define USE_ADC_INTERNAL
 #define USE_USB_CDC_HID
 #define USE_USB_MSC
-#define USE_MCO
 
 #if defined(STM32F40_41xxx) || defined(STM32F411xE)
 #define USE_OVERCLOCK


### PR DESCRIPTION
Also prevent F411 from being build with `USE_MCO`.